### PR TITLE
Fix possible fix(deps): mcp 1.27.2 → 1.28.1 (CVE-2026-59950) in requirements.txt

### DIFF
--- a/mcp_server/requirements.txt
+++ b/mcp_server/requirements.txt
@@ -2,7 +2,7 @@ fastapi==0.115.6
 uvicorn[standard]==0.32.1
 httpx==0.28.1
 python-dotenv==1.0.1
-mcp[cli]==1.27.2
+mcp[cli]==1.28.1
 fastembed==0.7.4
 PyYAML==6.0.3
 edge-tts==7.2.8


### PR DESCRIPTION
Proposing a fix for something flagged in `mcp_server/requirements.txt`. It is around line 5.

VULNERABILITY: CVE-2026-59950 (HIGH) affects the MCP Python SDK ('mcp' package, installed version 1.27.2) as declared in mcp_server/requirements.txt (line 5). Versions prior to 1.28.1 accept WebSocket handshakes in the deprecated mcp.server.websocket.websocket_server transport without validating Host or Origin headers, and the SDK provides no hook to restrict connecting origins. IMPACT: This enables Cross-Site WebSocket Hijacking (CSWSH). An attacker can host a malicious webpage that silently opens a WebSocket connection to a victim-reachable MCP server (e.g., bound to localhost or an intranet host) from the victim's browser. Since MCP servers expose tool invocation and resource access, a successful hijack can result in unauthorized tool execution, command execution, and data exfiltration. RISK LEVEL: HIGH — any deployment exposing the affected WebSocket transport should treat this as immediately exploitable. REMEDIATION: Upgrade 'mcp' to 1.28.1 or later. Recommended hardening: (1) migrate off the deprecated websocket transport in favor of Streamable HTTP/SSE, and (2) enforce an Origin allow-list at your reverse proxy/load balancer as defense-in-depth.

Update mcp dependency from 1.27.2 to 1.28.1 to address CVE-2026-59950 security advisory.

For reference: rule `CVE-2026-59950`. Rated high.

Take or leave whichever parts are useful. If this is not the right approach, closing is fine.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
